### PR TITLE
Add 'Windows Defender Credential Guard' option to provisioning wizard 

### DIFF
--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
@@ -1632,7 +1632,7 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 			proxySettings    	: workloadRequest.proxyConfiguration,
 			uefi             	: uefi,
 			secureBoot        	: workload.getConfigProperty('secureBoot'),
-			hardwareVirtualization  : workload.getConfigProperty('hardwareVirtualization'),
+			windowsCredentialGuard  : workload.getConfigProperty('windowsCredentialGuard'),
 			noAgent           	: (opts.config?.containsKey("noAgent") == true && opts.config.noAgent == true),
 			installAgent      	: (opts.config?.containsKey("noAgent") == false || (opts.config?.containsKey("noAgent") && opts.config.noAgent != true))
 

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
@@ -128,7 +128,7 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 			fieldContext : 'config',
 			fieldLabel : 'Categories',
 			inputType : OptionType.InputType.MULTI_SELECT,
-			displayOrder : 105,
+			displayOrder : 106,
 			optionSource: 'nutanixPrismCategories'
 
 		])

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
@@ -1617,23 +1617,24 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 
 		def runConfig = [:] + opts + buildRunConfig(server, imageExternalId, workloadRequest.networkConfiguration, config)
 		runConfig += [
-			workloadId        : workload.id,
-			accountId         : workload.account.id,
-			maxMemory         : maxMemory,
-			maxStorage        : maxStorage,
-			cpuCount          : maxCores,
-			maxCores          : maxCores,
-			coresPerSocket    : coresPerSocket,
-			numSockets		  : numSockets,
-			networkType       : workload.getConfigProperty('networkType'),
-			containerId       : workload.id,
-			workloadConfig    : workload.getConfigMap(),
-			timezone          : (workload.getConfigProperty('timezone') ?: cloud.timezone),
-			proxySettings     : workloadRequest.proxyConfiguration,
-			uefi              : uefi,
-			secureBoot        : workload.getConfigProperty('secureBoot'),
-			noAgent           : (opts.config?.containsKey("noAgent") == true && opts.config.noAgent == true),
-			installAgent      : (opts.config?.containsKey("noAgent") == false || (opts.config?.containsKey("noAgent") && opts.config.noAgent != true))
+			workloadId        	: workload.id,
+			accountId         	: workload.account.id,
+			maxMemory         	: maxMemory,
+			maxStorage        	: maxStorage,
+			cpuCount          	: maxCores,
+			maxCores          	: maxCores,
+			coresPerSocket    	: coresPerSocket,
+			numSockets		: numSockets,
+			networkType       	: workload.getConfigProperty('networkType'),
+			containerId       	: workload.id,
+			workloadConfig    	: workload.getConfigMap(),
+			timezone          	: (workload.getConfigProperty('timezone') ?: cloud.timezone),
+			proxySettings    	: workloadRequest.proxyConfiguration,
+			uefi             	: uefi,
+			secureBoot        	: workload.getConfigProperty('secureBoot'),
+			hardwareVirtualization  : workload.getConfigProperty('hardwareVirtualization'),
+			noAgent           	: (opts.config?.containsKey("noAgent") == true && opts.config.noAgent == true),
+			installAgent      	: (opts.config?.containsKey("noAgent") == false || (opts.config?.containsKey("noAgent") && opts.config.noAgent != true))
 
 		]
 		return runConfig

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
@@ -127,7 +127,7 @@ class NutanixPrismComputeUtility {
 			if(runConfig.secureBoot) {
 				resources['machine_type'] = "Q35"
 				resources['boot_config']['boot_type'] = "SECURE_BOOT"
-				if(runConfig.hardwareVirtualization) {
+				if(runConfig.windowsCredentialGuard) {
 					resources['hardware_virtualization_enabled'] = true
 				}
 			}

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
@@ -127,6 +127,9 @@ class NutanixPrismComputeUtility {
 			if(runConfig.secureBoot) {
 				resources['machine_type'] = "Q35"
 				resources['boot_config']['boot_type'] = "SECURE_BOOT"
+				if(runConfig.hardwareVirtualization) {
+					resources['hardware_virtualization_enabled'] = true
+				}
 			}
 		}
 

--- a/src/main/resources/scribe/nutanix-prism-instances.scribe
+++ b/src/main/resources/scribe/nutanix-prism-instances.scribe
@@ -15,7 +15,7 @@ resource "instance-type" "nutanix-prism-provision-provider" {
 		option-type.nutanix-prism-provision-image,
 		option-type.nutanix-prism-provision-uefi,
 		option-type.nutanix-prism-provision-secure-boot,
-		option-type.nutanix-prism-provision-hardware-virtualization
+		option-type.nutanix-prism-provision-credential-guard
 	]
 	pluginIconPath = "nutanix-prism.svg"
 	pluginIconHidpiPath= "nutanix-prism.svg"

--- a/src/main/resources/scribe/nutanix-prism-instances.scribe
+++ b/src/main/resources/scribe/nutanix-prism-instances.scribe
@@ -14,7 +14,8 @@ resource "instance-type" "nutanix-prism-provision-provider" {
 	optionTypes = [
 		option-type.nutanix-prism-provision-image,
 		option-type.nutanix-prism-provision-uefi,
-		option-type.nutanix-prism-provision-secure-boot
+		option-type.nutanix-prism-provision-secure-boot,
+		option-type.nutanix-prism-provision-hardware-virtualization
 	]
 	pluginIconPath = "nutanix-prism.svg"
 	pluginIconHidpiPath= "nutanix-prism.svg"

--- a/src/main/resources/scribe/nutanix-prism-option-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-option-types.scribe
@@ -33,10 +33,10 @@ resource "option-type" "nutanix-prism-provision-secure-boot" {
 	fieldGroup = "Nutanix Prism Boot Options"
 }
 
-resource "option-type" "nutanix-prism-provision-hardware-virtualization" {
+resource "option-type" "nutanix-prism-provision-credential-guard" {
 	name = "windows defender credential guard"
-	code = "nutanix-prism-provision-hardware-virtualization"
-	fieldName = "hardwareVirtualization"
+	code = "nutanix-prism-provision-credential-guard"
+	fieldName = "windowsCredentialGuard"
 	fieldContext = "config"
 	fieldLabel = "Windows Defender Credential Guard"
 	type = "checkbox"

--- a/src/main/resources/scribe/nutanix-prism-option-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-option-types.scribe
@@ -34,7 +34,7 @@ resource "option-type" "nutanix-prism-provision-secure-boot" {
 }
 
 resource "option-type" "nutanix-prism-provision-hardware-virtualization" {
-	name = "hardware virtualization security"
+	name = "windows defender credential guard"
 	code = "nutanix-prism-provision-hardware-virtualization"
 	fieldName = "hardwareVirtualization"
 	fieldContext = "config"

--- a/src/main/resources/scribe/nutanix-prism-option-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-option-types.scribe
@@ -33,3 +33,14 @@ resource "option-type" "nutanix-prism-provision-secure-boot" {
 	fieldGroup = "Nutanix Prism Boot Options"
 }
 
+resource "option-type" "nutanix-prism-provision-hardware-virtualization" {
+	name = "hardware virtualization security"
+	code = "nutanix-prism-provision-hardware-virtualization"
+	fieldName = "hardwareVirtualization"
+	fieldContext = "config"
+	fieldLabel = "Windows Defender Credential Guard"
+	type = "checkbox"
+	displayOrder = 105
+	visibleOnCode = "nutanix-prism-provision-secure-boot:on"
+	fieldGroup = "Nutanix Prism Boot Options"
+}

--- a/src/main/resources/scribe/nutanix-prism-option-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-option-types.scribe
@@ -41,6 +41,6 @@ resource "option-type" "nutanix-prism-provision-credential-guard" {
 	fieldLabel = "Windows Defender Credential Guard"
 	type = "checkbox"
 	displayOrder = 105
-	visibleOnCode = "nutanix-prism-provision-secure-boot:on"
+	visibleOnCode = "matchAll::nutanix-prism-provision-uefi:(on),nutanix-prism-provision-secure-boot:(on)"
 	fieldGroup = "Nutanix Prism Boot Options"
 }


### PR DESCRIPTION
Added a new checkbox called 'Windows Defender Credential Guard' that will be visible when UEFI and Secure Boot are checked. 

It sets the `hardware_virtualization_enabled = true` in the vm resource spec when a new Prism Central VM is created. 

Tested on Windows and Ubuntu and it hasn't broken anything :)