### PR TITLE
Retryable APIs if Nutanix Responds with 409 "Edit conflict: please retry change."

### DIFF
--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
@@ -1134,7 +1134,7 @@ class NutanixPrismComputeUtility {
 
 	private static ServiceResponse callRetryableApi(String path, HttpApiClient client, Map authConfig, String method, Map headers = null, Map body = null, Map opts = [:], RetryUtility retryUtility = null) {
 		if(!retryUtility) {
-			retryUtility = getSimpleRetryUtility()
+			retryUtility = getLinearRetryUtility()
 		}
 		def retryClosure = { RetryUtility ru ->
 			def currentAttempt = ru.getCurrentAttempt()
@@ -1212,11 +1212,10 @@ class NutanixPrismComputeUtility {
 		return retryUtility
 	}
 
-	private static RetryUtility getLinearRetryUtility(Long initialSleepTime = 500l, Long maxAttempts = 5l) {
+	private static RetryUtility getLinearRetryUtility(Long initialSleepTime = 1000l, Long maxAttempts = 60l) {
 		RetryUtility retryUtility
 		AbstractRetryDelayPolicy delayPolicy = new LinearRetryDelayPolicy()
 		delayPolicy.setInitialSleepTime(initialSleepTime)
-		delayPolicy.setMaxSleepTime(15000l)
 		retryUtility = new RetryUtility(delayPolicy)
 		retryUtility.setMaxAttempts(maxAttempts)
 		retryUtility.setRetryableErrors([(getRetryExceptionClass()): []])

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
@@ -1212,7 +1212,7 @@ class NutanixPrismComputeUtility {
 		return retryUtility
 	}
 
-	private static RetryUtility getLinearRetryUtility(Long initialSleepTime = 1000l, Long maxAttempts = 60l) {
+	private static RetryUtility getLinearRetryUtility(Long initialSleepTime = 1000l, Long maxAttempts = 30l) {
 		RetryUtility retryUtility
 		AbstractRetryDelayPolicy delayPolicy = new LinearRetryDelayPolicy()
 		delayPolicy.setInitialSleepTime(initialSleepTime)

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/utils/NutanixPrismComputeUtility.groovy
@@ -896,24 +896,12 @@ class NutanixPrismComputeUtility {
 		return retryUtility
 	}
 
-	private Exception getRetryException() {
+	private static Exception getRetryException() {
 		return new PrismRetryException()
 	}
 
-	private getRetryExceptionClass() {
+	private static getRetryExceptionClass() {
 		return getRetryException().getClass()
-	}
-
-	class PrismRetryException extends Exception {
-		public PrismRetryException() {
-			super()
-		}
-		public PrismRetryException(String message) {
-			super(message)
-		}
-		public PrismRetryException(String message, Throwable cause) {
-			super(message, cause)
-		}
 	}
 
 	private static ServiceResponse callListApi(HttpApiClient client, String kind, String path, Map authConfig) {
@@ -1232,5 +1220,17 @@ class NutanixPrismComputeUtility {
 			}
 			return nicMap
 		}
+	}
+}
+
+class PrismRetryException extends Exception {
+	public PrismRetryException() {
+		super()
+	}
+	public PrismRetryException(String message) {
+		super(message)
+	}
+	public PrismRetryException(String message, Throwable cause) {
+		super(message, cause)
 	}
 }

--- a/src/main/groovy/com/morpheusdata/retry/RetryException.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryException.groovy
@@ -1,0 +1,33 @@
+package com.morpheusdata.retry
+/**
+ * Thrown by retry utility.
+ * @author Chris Taylor
+ */
+public class RetryException extends Exception {
+  
+  private final String code;
+
+  public RetryException(String code) {
+    super();
+    this.code = code;
+  }
+
+  public RetryException(String message, Throwable cause, String code) {
+    super(message, cause);
+    this.code = code;
+  }
+
+  public RetryException(String message, String code) {
+    super(message);
+    this.code = code;
+  }
+
+  public RetryException(Throwable cause, String code) {
+    super(cause);
+    this.code = code;
+  }
+
+  public String getCode() {
+    return this.code;
+  }
+}

--- a/src/main/groovy/com/morpheusdata/retry/RetryUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryUtility.groovy
@@ -1,0 +1,92 @@
+package com.morpheusdata.retry
+
+import com.morpheusdata.retry.policies.AbstractRetryDelayPolicy
+
+import javax.net.ssl.SSLHandshakeException
+
+/**
+ * Utility for executing a RetryableFunction
+ * @author Chris Taylor
+ */
+class RetryUtility implements RetryUtilityInterface{
+
+  //Expected communication errors that will trigger a sleep and retry action
+  private LinkedHashMap<Class<? extends Exception>, ArrayList<String>> retryableErrors = [(SSLHandshakeException.class): [], (SocketTimeoutException.class): []]
+  private AbstractRetryDelayPolicy retryPolicy
+  Long maxAttempts = 10
+
+  RetryUtility(AbstractRetryDelayPolicy retryPolicy, LinkedHashMap<Class<? extends Exception>, ArrayList<String>> retryableErrors = [:], Long maxAttempts = null) {
+    if (retryableErrors) {this.retryableErrors = retryableErrors}
+    this.retryPolicy = retryPolicy
+    if(maxAttempts) {this.maxAttempts = maxAttempts}
+  }
+
+  /**
+   * Execute a retryable function
+   */
+  @Override
+  def execute(RetryableFunction retryableFunction, RetryableFunctionUpdater retryableFunctionUpdater = null) {
+    if (retryableFunctionUpdater) {retryableFunctionUpdater.setRetryableFunction(retryableFunction)}
+    for (Long attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      try {
+        return retryableFunction.execute()
+      } catch (Exception e) {
+        def retryRequired = isRetryRequired(e)
+        if(retryRequired) {
+          Long sleepTime = retryPolicy.calculateRetryDelay(attempt)
+          goToSleep(sleepTime)
+        } else {
+          throw e
+        }
+        if (retryableFunctionUpdater) {retryableFunctionUpdater.updateParams()} //update params of RetryFunction
+      }
+    }
+    throw new RetryException( "Maximum Retry Attempts Reached", "1000")
+  }
+  
+  def getRetryableErrors() {
+    return retryableErrors
+  }
+
+  void setRetryableErrors(LinkedHashMap<Class<? extends Exception>, ArrayList<String>> retryableErrors) {
+    this.retryableErrors = retryableErrors
+  }
+
+  AbstractRetryDelayPolicy getRetryPolicy() {
+    return this.retryPolicy
+  }
+
+  void setDelayPolicy(AbstractRetryDelayPolicy retryPolicy) {
+    this.retryPolicy = retryPolicy
+  }
+
+  Long getMaxAttempts() {
+    return this.maxAttempts
+  }
+  
+  protected isRetryRequired(Exception e) {
+    def rtn = false
+    if (e?.getClass() != null) {
+      this.retryableErrors.any{ clazz, messages ->
+        if (e?.getClass() == clazz) {
+            if (messages) {
+                rtn = messages.any {it =~ e?.getMessage()}
+            } else {
+                rtn = true
+            }
+        }
+      }
+    }
+    return rtn
+  }
+
+  /**
+   * Thread sleep for sleepTime
+   * @param sleepTime
+   * @return
+   */
+  protected static goToSleep(Long sleepTime) {
+    println "Sleeping for ${sleepTime}"
+    Thread.sleep(sleepTime)
+  }
+}

--- a/src/main/groovy/com/morpheusdata/retry/RetryUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryUtility.groovy
@@ -14,6 +14,7 @@ class RetryUtility implements RetryUtilityInterface{
   private LinkedHashMap<Class<? extends Exception>, ArrayList<String>> retryableErrors = [(SSLHandshakeException.class): [], (SocketTimeoutException.class): []]
   private AbstractRetryDelayPolicy retryPolicy
   Long maxAttempts = 10
+  Long currentAttempt = 0
 
   RetryUtility(AbstractRetryDelayPolicy retryPolicy, LinkedHashMap<Class<? extends Exception>, ArrayList<String>> retryableErrors = [:], Long maxAttempts = null) {
     if (retryableErrors) {this.retryableErrors = retryableErrors}
@@ -28,6 +29,7 @@ class RetryUtility implements RetryUtilityInterface{
   def execute(RetryableFunction retryableFunction, RetryableFunctionUpdater retryableFunctionUpdater = null) {
     if (retryableFunctionUpdater) {retryableFunctionUpdater.setRetryableFunction(retryableFunction)}
     for (Long attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      this.currentAttempt++
       try {
         return retryableFunction.execute()
       } catch (Exception e) {
@@ -63,6 +65,10 @@ class RetryUtility implements RetryUtilityInterface{
   Long getMaxAttempts() {
     return this.maxAttempts
   }
+
+  Long getCurrentAttempt() {
+    return this.currentAttempt
+  }
   
   protected isRetryRequired(Exception e) {
     def rtn = false
@@ -86,7 +92,6 @@ class RetryUtility implements RetryUtilityInterface{
    * @return
    */
   protected static goToSleep(Long sleepTime) {
-    println "Sleeping for ${sleepTime}"
     Thread.sleep(sleepTime)
   }
 }

--- a/src/main/groovy/com/morpheusdata/retry/RetryUtilityInterface.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryUtilityInterface.groovy
@@ -1,0 +1,12 @@
+package com.morpheusdata.retry
+
+interface RetryUtilityInterface {
+    
+  /**
+   * Execute a function and retries per defined policies
+   * @param backOffFunction BackOffFunction that will be executed
+   * @param updateParamsFunction Function to update params of BackOffFunction
+   * @return
+   */
+  def execute(RetryableFunction backOffFunction, RetryableFunctionUpdater updateParamsFunction)
+}

--- a/src/main/groovy/com/morpheusdata/retry/RetryableFunction.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryableFunction.groovy
@@ -1,0 +1,38 @@
+package com.morpheusdata.retry
+/**
+ * Provide a retryable function
+ * @param <T>
+ * @author Chris Taylor
+ */
+class RetryableFunction<T> {
+
+  // The closure that can be retried
+  private Closure retryableClosure
+  // The list of arguments to the function
+  private ArrayList<T> args
+
+  public RetryableFunction(Closure fn, T... args){
+    this.retryableClosure = fn
+    this.args = args
+  }
+
+  def execute() {
+    return this.retryableClosure(*this.args)
+  }
+
+  Closure getRetryableClosure() {
+    return retryableClosure
+  }
+
+  void setRetryableClosure(Closure retryableClosure) {
+    this.retryableClosure = retryableClosure
+  }
+
+  ArrayList<T> getArgs() {
+    return args
+  }
+
+  void setArgs(T... args) {
+    this.args = args
+  }
+}

--- a/src/main/groovy/com/morpheusdata/retry/RetryableFunctionUpdater.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/RetryableFunctionUpdater.groovy
@@ -1,0 +1,64 @@
+package com.morpheusdata.retry
+/**
+ * Provide a function that can update params of a RetryableFunction
+ * @param <T>
+ * @author Chris Taylor
+ */
+class RetryableFunctionUpdater {
+  // The closure that will update params for the RetryableFunction
+  private Closure updaterClosure
+  // Additional opts to the RetryableFunction
+  private opts
+  //RetryableFunction to update
+  private RetryableFunction retryableFunction
+
+  public RetryableFunctionUpdater(RetryableFunction retryableFunction, Closure updateParamsFunction, opts = null){
+    this.updaterClosure = updateParamsFunction
+    this.opts = opts
+    this.retryableFunction = retryableFunction
+  }
+
+  public RetryableFunctionUpdater(Closure updateParamsFunction, opts = null){
+    this.updaterClosure = updateParamsFunction
+    this.opts = opts
+  }
+
+  def updateParams() {
+    if (this.retryableFunction) {
+      def params = this.retryableFunction.getArgs()
+      if (this.opts) {
+        params = params + [this.opts]
+      }
+      if(this.updaterClosure.getParameterTypes()) {
+        params = this.updaterClosure(*params)
+      } else {
+        params = this.updaterClosure()
+      }
+      this.retryableFunction.setArgs(*params)
+    }
+  }
+
+  Closure getUpdaterClosure() {
+    return updaterClosure
+  }
+
+  void setUpdateParamsClosure(Closure updaterClosure) {
+    this.updaterClosure = updaterClosure
+  }
+
+  Map getOpts() {
+    return opts
+  }
+
+  void setOpts(opts) {
+    this.opts = opts
+  }
+
+  RetryableFunction getRetryableFunction() {
+    return retryableFunction
+  }
+
+  void setRetryableFunction(RetryableFunction retryableFunction) {
+    this.retryableFunction = retryableFunction
+  }
+}

--- a/src/main/groovy/com/morpheusdata/retry/policies/AbstractRetryDelayPolicy.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/policies/AbstractRetryDelayPolicy.groovy
@@ -1,0 +1,45 @@
+package com.morpheusdata.retry.policies
+
+abstract class AbstractRetryDelayPolicy {
+
+  Long maxSleepTime
+  static final long DEFAULT_INITIAL_SLEEP_TIME = 1000l //1 second
+  Long initialSleepTime = DEFAULT_INITIAL_SLEEP_TIME
+
+  Long getMaxSleepTime() {
+    return this.maxSleepTime
+  }
+
+  void setMaxSleepTime(Long maxSleepTime) {
+    this.maxSleepTime = parseMaxSleepTime(maxSleepTime)
+  }
+
+  private static Long parseMaxSleepTime(Long maxSleepTime) {
+    if (!maxSleepTime || maxSleepTime <= 0) {
+      return null
+    }
+    return maxSleepTime
+  }
+
+  Long getInitialSleepTime() {
+    return this.initialSleepTime
+  }
+
+  void setInitialSleepTime(Long initialSleepTime) {
+    this.initialSleepTime = parseInitialSleepTime(initialSleepTime)
+  }
+
+  private static Long parseInitialSleepTime(Long initialSleepTime) {
+    if (!initialSleepTime || initialSleepTime <= 0) {
+      return null
+    }
+    return initialSleepTime
+  }
+
+  static long getDefaultInitialSleepTime() {
+    return DEFAULT_INITIAL_SLEEP_TIME
+  }
+
+  abstract Long calculateRetryDelay(Long retryAttempt)
+
+}

--- a/src/main/groovy/com/morpheusdata/retry/policies/ExponentialRetryDelayPolicy.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/policies/ExponentialRetryDelayPolicy.groovy
@@ -1,0 +1,37 @@
+package com.morpheusdata.retry.policies
+
+class ExponentialRetryDelayPolicy extends AbstractRetryDelayPolicy {
+
+  Long multiplier
+
+  Long getMultiplier() {
+    return multiplier
+  }
+
+  void setMultiplier(Long multiplier) {
+    this.multiplier = parseMultiplier(multiplier)
+  }
+
+  private static Long parseMultiplier(Long multiplier) {
+    if (!multiplier || multiplier <= 0) {
+      return 2l
+    }
+    return multiplier
+  }
+
+  @Override
+  Long calculateRetryDelay(Long attempt) {
+    Long sleepTime = getDefaultInitialSleepTime()
+    if(this.initialSleepTime) {
+      sleepTime = this.initialSleepTime
+    }
+    if(attempt > 1) {
+      sleepTime = (sleepTime * Math.pow(multiplier, attempt)).toLong()
+    }
+    if(this.maxSleepTime && (sleepTime > this.maxSleepTime)) {
+      sleepTime = this.maxSleepTime
+    }
+    return sleepTime
+  }
+
+}

--- a/src/main/groovy/com/morpheusdata/retry/policies/LinearRetryDelayPolicy.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/policies/LinearRetryDelayPolicy.groovy
@@ -1,0 +1,18 @@
+package com.morpheusdata.retry.policies
+
+class LinearRetryDelayPolicy extends AbstractRetryDelayPolicy{
+
+  @Override
+  Long calculateRetryDelay(Long attempt) {
+    Long sleepTime = getDefaultInitialSleepTime()
+    if(this.initialSleepTime) {
+      sleepTime = this.initialSleepTime
+    }
+    sleepTime = sleepTime * attempt
+    if(this.maxSleepTime && (sleepTime > this.maxSleepTime)) {
+      sleepTime = this.maxSleepTime
+    }
+    return sleepTime
+  }
+
+}

--- a/src/main/groovy/com/morpheusdata/retry/policies/SimpleRetryDelayPolicy.groovy
+++ b/src/main/groovy/com/morpheusdata/retry/policies/SimpleRetryDelayPolicy.groovy
@@ -1,0 +1,16 @@
+package com.morpheusdata.retry.policies
+
+class SimpleRetryDelayPolicy extends AbstractRetryDelayPolicy {
+
+  @Override
+  Long calculateRetryDelay(Long attempt) {
+    Long sleepTime =  getDefaultInitialSleepTime()
+    if(this.initialSleepTime) {
+      sleepTime = this.initialSleepTime
+    }
+    if(this.maxSleepTime && (sleepTime > this.maxSleepTime)) {
+      sleepTime = this.maxSleepTime
+    }
+    return sleepTime
+  }
+}


### PR DESCRIPTION
Nutanix Prism PUT, POST and DELETE APIs can respond with the following:
"Edit conflict: please retry change."
therefore I have added the ability to retry API requests based on a set of defined conditions.

What I have added:
1) A lightweight retry utility.
 This utility should be hosted in its own package and broken out from here and added as a dependency. 
 Retry currently support simple, linear and exponential retry delays. Simple will always sleep for the same time between retries.
2) The stop VM and delete VM API requests are now retryable, as it was these requests users were having issues with
This should be extended to other methods as needed. 