### PR TITLE
Update the disk config during provision of a template. 

### DIFF
--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
@@ -1213,124 +1213,7 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 				def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, updateResourcesResult.data?.status?.execution_context?.task_uuid)
 			}
 
-			//disks
-			//skip controllers for now
-			//remove disks to delete
-			def volumesToDelete = resizeRequest.volumesDelete?.collect {it.externalId}
-			if(volumesToDelete.size() > 0) {
-				serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
-				vmBody = serverDetails?.data
-				def newDiskList = vmBody.spec?.resources?.disk_list?.findAll { !volumesToDelete.contains(it.uuid) }
-				vmBody.spec?.resources?.disk_list = newDiskList
-				def deleteResults = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
-				if(deleteResults.success == true) {
-					if(deleteResults.data?.status?.execution_context?.task_uuid) {
-						def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, deleteResults.data?.status?.execution_context?.task_uuid)
-					}
-					log.info("resize volume delete complete: ${deleteResults.success}")
-					resizeRequest.volumesDelete?.each { StorageVolume volume ->
-						morpheusContext.async.storageVolume.remove([volume], server, true).blockingGet()
-					}
-				}
-			}
-
-			//update existing disks
-			resizeRequest.volumesUpdate?.each { UpdateModel<StorageVolume> volumeUpdate ->
-				StorageVolume existing = volumeUpdate.existingModel
-				Map updateProps = volumeUpdate.updateProps
-				log.info("resizing vm storage: {}", volumeUpdate)
-				if (updateProps.maxStorage > existing.maxStorage) {
-					serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
-					vmBody = serverDetails?.data
-					def newDiskList = vmBody.spec?.resources?.disk_list
-					def diskMap = newDiskList.find{it.uuid == existing.externalId}
-					diskMap.disk_size_bytes = updateProps.maxStorage
-					diskMap.remove("disk_size_mib")
-					def result = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
-					if (result.success) {
-						if(result.data?.status?.execution_context?.task_uuid) {
-							def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, result.data?.status?.execution_context?.task_uuid)
-						}
-						existing.maxStorage = updateProps.maxStorage
-						morpheusContext.async.storageVolume.save([existing]).blockingGet()
-					} else {
-						rtn.setError(result.msg ?: "Failed to expand Disk: ${existing.name}")
-						log.warn("error resizing disk: ${result.msg}")
-					}
-				}
-			}
-
-			//add new disks
-			def datastoreIds = []
-			def storageVolumeTypes = [:]
-			resizeRequest.volumesAdd?.each { Map volumeAdd ->
-				datastoreIds << volumeAdd.datastoreId.toLong()
-				def storageVolumeTypeId = volumeAdd.storageType.toLong()
-				if(!storageVolumeTypes[storageVolumeTypeId]) {
-					storageVolumeTypes[storageVolumeTypeId] = morpheusContext.async.storageVolume.storageVolumeType.get(storageVolumeTypeId).blockingGet()
-				}
-
-			}
-			datastoreIds = datastoreIds.unique()
-			def datastores = morpheusContext.async.cloud.datastore.listById(datastoreIds).toMap {it.id.toLong()}.blockingGet()
-			resizeRequest.volumesAdd?.each { Map volumeAdd ->
-				serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
-				vmBody = serverDetails?.data
-				log.info("resizing vm adding storage: {}", volumeAdd)
-				if (!volumeAdd.maxStorage) {
-					volumeAdd.maxStorage = volumeAdd.size ? (volumeAdd.size.toDouble() * ComputeUtility.ONE_GIGABYTE).toLong() : 0
-				}
-				def storageVolumeType = storageVolumeTypes[volumeAdd.storageType.toLong()]
-				def datastore = datastores[volumeAdd.datastoreId.toLong()]
-				def targetIndex = vmBody.spec?.resources?.disk_list?.size()
-				if(targetIndex != null) {
-					//account for ide.0
-					targetIndex--
-				} else {
-					targetIndex = 0
-				}
-				def newDiskList = vmBody.spec?.resources?.disk_list
-
-				def diskConfig = [
-					device_properties: [
-						device_type: "DISK",
-						disk_address: [
-							adapter_type: storageVolumeType.name.toUpperCase(),
-							device_index: targetIndex
-						],
-					],
-					disk_size_bytes: volumeAdd.maxStorage,
-					storage_config: [
-						storage_container_reference: [
-							uuid: datastore.externalId,
-							name: datastore.name,
-							kind: "storage_container",
-						]
-					]
-				]
-				newDiskList << diskConfig
-				vmBody.spec.resources.disk_list = newDiskList
-				def addDiskResults = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
-				if(addDiskResults.success) {
-					//wait for operation to complete
-					if(addDiskResults.data?.status?.execution_context?.task_uuid) {
-						def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, addDiskResults.data?.status?.execution_context?.task_uuid)
-					}
-					serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
-					vmBody = serverDetails?.data
-					def newDisk = vmBody.spec.resources.disk_list.find {it.device_properties.disk_address.adapter_type == storageVolumeType.name.toUpperCase() && it.device_properties.disk_address.device_index == targetIndex}
-					def newVolume = NutanixPrismSyncUtils.buildStorageVolume(server.account, server, volumeAdd, targetIndex)
-					newVolume.externalId = newDisk.uuid
-					newVolume.type = new StorageVolumeType(id: volumeAdd.storageType.toLong())
-					morpheusContext.async.storageVolume.create([newVolume], server).blockingGet()
-					// Need to refetch the server
-					server = morpheusContext.async.computeServer.get(server.id).blockingGet()
-				} else {
-					//do stuff here to bubble up results
-					rtn.setError("error adding disk: ${addDiskResults?.msg}")
-					log.warn("error adding disk: ${addDiskResults}")
-				}
-			}
+			internalResizeDisks(resizeRequest, client, authConfig, vmId, server, rtn, serverDetails, vmBody)
 
 
 			//networks
@@ -1421,6 +1304,127 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 			rtn.setError("Error resizing workload: ${e}")
 		}
 		return rtn
+	}
+
+	private void internalResizeDisks(ResizeRequest resizeRequest, HttpApiClient client, authConfig, vmId, ComputeServer server, rtn, serverDetails, vmBody) {
+		//disks
+		//skip controllers for now
+		//remove disks to delete
+		def volumesToDelete = resizeRequest.volumesDelete?.collect { it.externalId }
+		if (volumesToDelete.size() > 0) {
+			serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
+			vmBody = serverDetails?.data
+			def newDiskList = vmBody.spec?.resources?.disk_list?.findAll { !volumesToDelete.contains(it.uuid) }
+			vmBody.spec?.resources?.disk_list = newDiskList
+			def deleteResults = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
+			if (deleteResults.success == true) {
+				if (deleteResults.data?.status?.execution_context?.task_uuid) {
+					def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, deleteResults.data?.status?.execution_context?.task_uuid)
+				}
+				log.info("resize volume delete complete: ${deleteResults.success}")
+				resizeRequest.volumesDelete?.each { StorageVolume volume ->
+					morpheusContext.async.storageVolume.remove([volume], server, true).blockingGet()
+				}
+			}
+		}
+
+		//update existing disks
+		resizeRequest.volumesUpdate?.each { UpdateModel<StorageVolume> volumeUpdate ->
+			StorageVolume existing = volumeUpdate.existingModel
+			Map updateProps = volumeUpdate.updateProps
+			log.info("resizing vm storage: {}", volumeUpdate)
+			if (updateProps.maxStorage > existing.maxStorage) {
+				serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
+				vmBody = serverDetails?.data
+				def newDiskList = vmBody.spec?.resources?.disk_list
+				def diskMap = newDiskList.find { it.uuid == existing.externalId }
+				diskMap.disk_size_bytes = updateProps.maxStorage
+				diskMap.remove("disk_size_mib")
+				def result = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
+				if (result.success) {
+					if (result.data?.status?.execution_context?.task_uuid) {
+						def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, result.data?.status?.execution_context?.task_uuid)
+					}
+					existing.maxStorage = updateProps.maxStorage
+					morpheusContext.async.storageVolume.save([existing]).blockingGet()
+				} else {
+					rtn.setError(result.msg ?: "Failed to expand Disk: ${existing.name}")
+					log.warn("error resizing disk: ${result.msg}")
+				}
+			}
+		}
+
+		//add new disks
+		def datastoreIds = []
+		def storageVolumeTypes = [:]
+		resizeRequest.volumesAdd?.each { Map volumeAdd ->
+			datastoreIds << volumeAdd.datastoreId.toLong()
+			def storageVolumeTypeId = volumeAdd.storageType.toLong()
+			if (!storageVolumeTypes[storageVolumeTypeId]) {
+				storageVolumeTypes[storageVolumeTypeId] = morpheusContext.async.storageVolume.storageVolumeType.get(storageVolumeTypeId).blockingGet()
+			}
+
+		}
+		datastoreIds = datastoreIds.unique()
+		def datastores = morpheusContext.async.cloud.datastore.listById(datastoreIds).toMap { it.id.toLong() }.blockingGet()
+		resizeRequest.volumesAdd?.each { Map volumeAdd ->
+			serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
+			vmBody = serverDetails?.data
+			log.info("resizing vm adding storage: {}", volumeAdd)
+			if (!volumeAdd.maxStorage) {
+				volumeAdd.maxStorage = volumeAdd.size ? (volumeAdd.size.toDouble() * ComputeUtility.ONE_GIGABYTE).toLong() : 0
+			}
+			def storageVolumeType = storageVolumeTypes[volumeAdd.storageType.toLong()]
+			def datastore = datastores[volumeAdd.datastoreId.toLong()]
+			def targetIndex = vmBody.spec?.resources?.disk_list?.size()
+			if (targetIndex != null) {
+				//account for ide.0
+				targetIndex--
+			} else {
+				targetIndex = 0
+			}
+			def newDiskList = vmBody.spec?.resources?.disk_list
+
+			def diskConfig = [
+				device_properties: [
+					device_type : "DISK",
+					disk_address: [
+						adapter_type: storageVolumeType.name.toUpperCase(),
+						device_index: targetIndex
+					],
+				],
+				disk_size_bytes  : volumeAdd.maxStorage,
+				storage_config   : [
+					storage_container_reference: [
+						uuid: datastore.externalId,
+						name: datastore.name,
+						kind: "storage_container",
+					]
+				]
+			]
+			newDiskList << diskConfig
+			vmBody.spec.resources.disk_list = newDiskList
+			def addDiskResults = NutanixPrismComputeUtility.retryableUpdateVm(client, authConfig, vmId, vmBody)
+			if (addDiskResults.success) {
+				//wait for operation to complete
+				if (addDiskResults.data?.status?.execution_context?.task_uuid) {
+					def taskResult = NutanixPrismComputeUtility.checkTaskReady(client, authConfig, addDiskResults.data?.status?.execution_context?.task_uuid)
+				}
+				serverDetails = NutanixPrismComputeUtility.waitForPowerState(client, authConfig, vmId)
+				vmBody = serverDetails?.data
+				def newDisk = vmBody.spec.resources.disk_list.find { it.device_properties.disk_address.adapter_type == storageVolumeType.name.toUpperCase() && it.device_properties.disk_address.device_index == targetIndex }
+				def newVolume = NutanixPrismSyncUtils.buildStorageVolume(server.account, server, volumeAdd, targetIndex)
+				newVolume.externalId = newDisk.uuid
+				newVolume.type = new StorageVolumeType(id: volumeAdd.storageType.toLong())
+				morpheusContext.async.storageVolume.create([newVolume], server).blockingGet()
+				// Need to refetch the server
+				server = morpheusContext.async.computeServer.get(server.id).blockingGet()
+			} else {
+				//do stuff here to bubble up results
+				rtn.setError("error adding disk: ${addDiskResults?.msg}")
+				log.warn("error adding disk: ${addDiskResults}")
+			}
+		}
 	}
 
 	@Override
@@ -2105,8 +2109,6 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 			Process process = workloadRequest?.process ?: hostRequest?.process ?: null
 			morpheusContext.async.process.startProcessStep(process , new ProcessEvent(type: ProcessEvent.ProcessType.provisionConfig), 'configuring')
 
-
-
 			ComputeServer server = morpheusContext.async.computeServer.get(runConfig.serverId as Long).blockingGet()
 			Workload sourceWorkload
 			VirtualImage virtualImage
@@ -2256,7 +2258,7 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 							log.debug "Error configuring cloud-init - no appliance url"
 						}
 					}
-					def startResults
+					def startResults, reconfigureResults
 					//hack for inability to set project on cloned snapshot
 					if(runConfig.snapshotId && runConfig.projectReference) {
 						vmResource.data
@@ -2265,7 +2267,15 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 							vmResource.data.metadata.project_reference = runConfig.projectReference
 						}
 						startResults = NutanixPrismComputeUtility.updateVm(client, authConfig, server.externalId, vmResource.data)
-					} else {
+					} else if (runConfig.isTemplate) {
+						def serverDetail = NutanixPrismComputeUtility.getVm(client, authConfig, server.externalId)
+
+						applyDiskUpdateOnTemplateCreate(serverDetail, runConfig)
+						serverDetail.data.spec.resources.power_state = 'ON'
+						startResults = NutanixPrismComputeUtility.updateVm(client, authConfig, server.externalId, serverDetail.data)
+
+					}
+					else {
 						startResults = NutanixPrismComputeUtility.startVm(client, authConfig, server.externalId, vmResource.data)
 					}
 					log.debug("start: ${startResults.success}")
@@ -2383,6 +2393,49 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 			}
 		}
 
+	}
+
+	private applyDiskUpdateOnTemplateCreate(ServiceResponse serverDetail, Map runConfig) {
+		// Build a map of desired disks from runConfig, keyed by device_index and device_type
+		def rc_deviceIndex = runConfig.diskList.collectEntries { [ [ device_index : it.device_properties.disk_address.device_index,
+																	device_type : it.device_properties.device_type ]: it] }
+		// Build a map of current disks from serverDetail, only including those with device_type 'DISK'
+
+		def sd_deviceIndex = serverDetail.data.spec.resources.disk_list
+			.findAll { it.device_properties.device_type == 'DISK' }
+			.collectEntries {
+				[[ device_index : it.device_properties.disk_address.device_index,
+				   device_type : it.device_properties.device_type ]: it] }
+
+		// Update existing disks or add new ones from runConfig to serverDetail
+		rc_deviceIndex.each { rc_key, rc_diskListValue ->
+			def sd_disk = sd_deviceIndex[rc_key]
+			if (sd_disk && sd_disk.device_properties.device_type == 'DISK')
+			{	log.debug("Updating existing disk in serverDetail: ${sd_disk} - ${rc_diskListValue}")
+				// Update properties except for 'device_properties' and 'data_source_reference'
+				rc_diskListValue.each { key, value ->
+					if (!key.equalsIgnoreCase('device_properties') && !key.equalsIgnoreCase('data_source_reference')) {
+						sd_disk[key] = value
+					}
+				}
+
+				//Its likely the sd_disk came back with a disk_size_mib, so we should update that too.
+				sd_disk.disk_size_mib = rc_diskListValue.disk_size_mib ? rc_diskListValue.disk_size_mib : (rc_diskListValue.disk_size_bytes / (1024L * 1024L))
+				log.debug("finalizing disk update in serverDetail: ${sd_disk}")
+			} else {
+				// Add new disk to serverDetail
+				log.debug("Adding new disk to serverDetail: ${rc_key} - ${rc_diskListValue}")
+				sd_deviceIndex[rc_key] = rc_diskListValue
+				serverDetail.data.spec.resources.disk_list << rc_diskListValue
+			}
+		}
+		// Remove any disks from serverDetail that are not present in runConfig
+		sd_deviceIndex.eachWithIndex { Map.Entry entry, int index ->
+			if (!rc_deviceIndex[entry.key]) {
+				log.debug("Removing disk from serverDetail: ${entry.key} - ${entry.value}")
+				serverDetail.data.spec.resources.disk_list.remove(entry.value)
+			}
+		}
 	}
 
 	def finalizeVm(Map runConfig, ProvisionResponse provisionResponse) {


### PR DESCRIPTION
- extracted Disk logic from internalResizeServer to InternalResizeDisks as a small enhancement, should be unmodified otherwise.

Added `applyDiskUpdateOnTemplateCreate` which will Add/Update/Remove disks based on the users morpheus selections instead of what was embedded in the template.

Still some outstanding bugs in the frontend that may cause some issues here. 
1) adapter types aren't reflected right, which can cause a conflict during provisioning if there are cdrom drives (which don't show in morpheus). 
2) root drive may might show as 'root' instead of sda or some other name. 
