### PR TITLE
MORPH-6120 Update Standard OS Image Templates for Ubuntu and Debian

### DIFF
--- a/src/main/resources/scribe/nutanix-prism-compute-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-compute-types.scribe
@@ -1,21 +1,15 @@
+resource "compute-type-layout" "docker-nutanix-prism-ubuntu-16_04-single"
+	name = "Nutanix Prism Central Docker Ubuntu 16.04"
+	computeVersion = "16.04"
+	enabled = false
+	creatable = false
+}
+
 resource "compute-type-layout" "docker-nutanix-prism-ubuntu-18_04-single" {
 	code = "docker-nutanix-prism-ubuntu-18.04-single"
 	name = "Nutanix Prism Central Docker Ubuntu 18.04"
-	sortOrder = 5
 	computeVersion = "18.04"
 	description = "This will provision a single docker host vm in nutanix prism central."
-	serverCount = 1
-	memoryRequirement = 1024 * 1024 * 1024
-	hasAutoScale = true
-	type = "nutanix-prism-vm"
-	groupType = "docker-cluster"
-	computeServers = ["docker-nutanix-prism-ubuntu-18.04-set"]
-	optionTypes = [
-		{code = "nutanix-prism-provision-vpc"},
-		{code = "nutanix-prism-provision-cluster"},
-		{code = "nutanix-prism-provision-categories"},
-	]
-	provisionType = "nutanix-prism-provision-provider"
 	enabled = false
 	creatable = false
 }
@@ -101,7 +95,7 @@ resource "workload-type" "kubernetes-1_26_1-ubuntu-20_04-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [
@@ -131,7 +125,7 @@ resource "workload-type" "kubernetes-1_26_1-ubuntu-20_04-worker-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [
@@ -230,7 +224,7 @@ resource "workload-type" "kubernetes-1_27_7-ubuntu-20_04-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [
@@ -260,7 +254,7 @@ resource "workload-type" "kubernetes-1_27_7-ubuntu-20_04-worker-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [
@@ -359,7 +353,7 @@ resource "workload-type" "kubernetes-1_28_3-ubuntu-20_04-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [
@@ -392,7 +386,7 @@ resource "workload-type" "kubernetes-1_28_3-ubuntu-20_04-worker-nutanix-prism" {
 	serverType = "vm"
 	providerType = "nutanix-prism"
 	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20240304
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	containerPorts = [{code = "ubuntu.22"}]
 	provisionType = "nutanix-prism-provision-provider"
 	scripts = [

--- a/src/main/resources/scribe/nutanix-prism-compute-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-compute-types.scribe
@@ -1,4 +1,4 @@
-resource "compute-type-layout" "docker-nutanix-prism-ubuntu-16_04-single"
+resource "compute-type-layout" "docker-nutanix-prism-ubuntu-16_04-single" {
 	name = "Nutanix Prism Central Docker Ubuntu 16.04"
 	computeVersion = "16.04"
 	enabled = false

--- a/src/main/resources/scribe/nutanix-prism-compute-types.scribe
+++ b/src/main/resources/scribe/nutanix-prism-compute-types.scribe
@@ -1,41 +1,3 @@
-
-resource "workload-type" "docker-nutanix-prism-ubuntu-18_04" {
-	code = "docker-nutanix-prism-ubuntu-18.04"
-	shortName = "ubuntu"
-	name = "Docker Ubuntu 18.04"
-	account = null
-	ports = [22]
-	containerVersion = "18.04"
-	entryPoint = ""
-	mountLogs = "/var/log"
-	statTypeCode = "vm"
-	logTypeCode = "ubuntu"
-	showServerLogs = true
-	category = "ubuntu"
-	cloneType = "ubuntu"
-	priorityOrder = 0
-	serverType = "vm"
-	providerType = "nutanix-prism"
-	containerPorts = [{code = "ubuntu.22"}]
-	checkTypeCode = "vmCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-18_04-20230131
-	provisionType = "nutanix-prism-provision-provider"
-}
-
-resource "compute-type-set" "docker-nutanix-prism-ubuntu-18_04-set" {
-	code = "docker-nutanix-prism-ubuntu-18.04-set"
-	name = "docker host"
-	containerType = workload-type.docker-nutanix-prism-ubuntu-18_04
-	computeServerType = compute-server-type.nutanix-prism-linux
-	priorityOrder = 0
-	dynamicCount = true
-	nodeCount = 1
-	nodeType = "worker"
-	canAddNodes = true
-	installContainerRuntime = true
-	installStorageRuntime = true
-}
-
 resource "compute-type-layout" "docker-nutanix-prism-ubuntu-18_04-single" {
 	code = "docker-nutanix-prism-ubuntu-18.04-single"
 	name = "Nutanix Prism Central Docker Ubuntu 18.04"
@@ -54,14 +16,6 @@ resource "compute-type-layout" "docker-nutanix-prism-ubuntu-18_04-single" {
 		{code = "nutanix-prism-provision-categories"},
 	]
 	provisionType = "nutanix-prism-provision-provider"
-	enabled = false
-	creatable = false
-}
-
-resource "compute-type-layout" "docker-nutanix-prism-ubuntu-16_04-single" {
-	code = "docker-nutanix-prism-ubuntu-16.04-single"
-	name = "Nutanix Prism Central Docker Ubuntu 16.04"
-	computeVersion = "16.04"
 	enabled = false
 	creatable = false
 }

--- a/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
+++ b/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
@@ -1,3 +1,12 @@
+// 10
+resource "instance-type-layout" "nutanix-prism-debian-10-single"
+	code = "nutanix-prism-debian-10-single"
+	name = "Nutanix Prism Central VM"
+	description = "This will provision a single vm"
+	enabled = false
+	creatable = false
+}
+
 //11
 resource "os-type-image" "nutanix-prism-image-morpheus-debian-11" {
 	code               = "nutanix.prism.image.morpheus.debian.11"

--- a/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
+++ b/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
@@ -1,5 +1,5 @@
 // 10
-resource "instance-type-layout" "nutanix-prism-debian-10-single"
+resource "instance-type-layout" "nutanix-prism-debian-10-single" {
 	code = "nutanix-prism-debian-10-single"
 	name = "Nutanix Prism Central VM"
 	description = "This will provision a single vm"

--- a/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
+++ b/src/main/resources/scribe/nutanix-prism-debian-layouts.scribe
@@ -1,154 +1,8 @@
-//10
-resource "virtual-image" "nutanix-prism-image-morpheus-debian-10-20230308" {
-	code = "nutanix.prism.image.morpheus.debian.10.20230308"
-	category = "nutanix.prism.image.morpheus.debian"
-	name = "Morpheus Debian 10 20230308"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20230308/debian-10/morpheus-debian-10-amd64-20230308.qcow2"
-	imagePath = "qemu/20230308/debian-10"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "debian.10.64"
-		owner = null
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-resource "os-type-image" "nutanix-prism-image-morpheus-debian-10-20230308-disabled" {
-  code               = "nutanix.prism.image.morpheus.debian.10.20230308"
-  false              = false
-}
-
-resource "virtual-image" "nutanix-prism-image-morpheus-debian-10-20240604" {
-	code = "nutanix.prism.image.morpheus.debian.10.20240604"
-	category = "nutanix.prism.image.morpheus.debian"
-	name = "Morpheus Debian 10 20240604"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20240604/debian-10/morpheus-debian-10-amd64-20240604.qcow2"
-	imagePath = "qemu/20240604/debian-10"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "debian.10.64"
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-resource "os-type-image" "nutanix-prism-image-morpheus-debian-10-20240604-disabled" {
-  code               = "nutanix.prism.image.morpheus.debian.10.20240604"
-  enabled            = false
-}
-
-resource "os-type-image" "nutanix-prism-image-morpheus-debian-10" {
-	code               = "nutanix.prism.image.morpheus.debian.10"
-	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-debian-10-20240604
-	account            = null
-	osType = {
-		code = "debian.10.64"
-		owner = null
-	}
-}
-
-resource "workload-type" "nutanix-prism-debian-10" {
-	code = "nutanix-prism-debian-10"
-	shortName = "debian"
-	name = "Debian 10"
-	account = null
-	ports = [22]
-	containerVersion = "10"
-	entryPoint = ""
-	mountLogs = "/var/log"
-	statTypeCode = "vm"
-	logTypeCode = "debian"
-	showServerLogs = true
-	category = "debian"
-	cloneType = "debian"
-	priorityOrder = 0
-	serverType = "vm"
-	providerType = "nutanix-prism"
-	containerPorts = [{code = "debian.22"}]
-	actions = [{code = "generic-remove-node"}]
-	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-debian-10-20250218
-	provisionType  = "nutanix-prism-provision-provider"
-	backupType = "nutanixPrismSnapshot"
-}
-
-resource "workload-type-set" "nutanix-prism-debian-10-set" {
-	code = "nutanix-prism-debian-10-set"
-	containerType = workload-type.nutanix-prism-debian-10
-	priorityOrder = 0
-	dynamicCount = true
-	containerCount = 1
-}
-
-resource "instance-type-layout" "nutanix-prism-debian-10-single" {
-	code = "nutanix-prism-debian-10-single"
-	name = "Nutanix Prism Central VM"
-	account = null
-	sortOrder = 10
-	instanceVersion = "10"
-	description = "This will provision a single vm"
-	instanceType {
-		code = "debian"
-	}
-	serverCount = 1
-	hasAutoScale = true
-	portCount = 1
-	serverType = "vm"
-	enabled = false
-	creatable = false
-	supportsConvertToManaged = true
-	containers = [
-		workload-type-set.nutanix-prism-debian-10-set
-	]
-	actions = [{code = "generic-add-node"}]
-	provisionType = "nutanix-prism-provision-provider"
-}
-
-resource "scale-action" "nutanix-prism-debian-10-single" {
-	code = "nutanix-prism-debian-10-single"
-	scaleType = "action"
-	layout = instance-type-layout.nutanix-prism-debian-10-single
-	upAction {
-		code = "generic-add-node"
-	}
-	downAction {
-		code = "generic-remove-node"
-	}
-}
-
 //11
-resource "virtual-image" "nutanix-prism-image-morpheus-debian-11-20230308" {
-	code = "nutanix.prism.image.morpheus.debian.11.20230308"
-	category = "nutanix.prism.image.morpheus.debian"
-	name = "Morpheus Debian 11 20230308"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20230308/debian-11/morpheus-debian-11-amd64-20230308.qcow2"
-	imagePath = "qemu/20230308/debian-11"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "debian.11.64"
-		owner = null
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-resource "os-type-image" "nutanix-prism-image-morpheus-debian-11-disabled" {
-  code               = "nutanix.prism.image.morpheus.debian.11.20230308"
-  enabled            = false
-}
-
 resource "os-type-image" "nutanix-prism-image-morpheus-debian-11" {
 	code               = "nutanix.prism.image.morpheus.debian.11"
 	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-debian-11-20250218
+	virtualImage       = virtual-image.nutanix-prism-image-morpheus-debian-11-20260203
 	account            = null
 	osType = {
 		code = "debian.11.64"
@@ -156,13 +10,13 @@ resource "os-type-image" "nutanix-prism-image-morpheus-debian-11" {
 	}
 }
 
-resource "virtual-image" "nutanix-prism-image-morpheus-debian-11-20250218" {
-	code = "nutanix.prism.image.morpheus.debian.11.20250218"
+resource "virtual-image" "nutanix-prism-image-morpheus-debian-11-20260203" {
+	code = "nutanix.prism.image.morpheus.debian.11.20260203"
 	category = "nutanix.prism.image.morpheus.debian"
-	name = "Morpheus Debian 11 20250218"
+	name = "Morpheus Debian 11 20260203"
 	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/debian-11/morpheus-debian-11-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/debian-11"
+	remotePath = "https://morpheus-images.s3.amazonaws.com/qemu/20260203/debian-11/morpheus-debian-11-amd64-20260203.qcow2"
+	imagePath = "qemu/20260203/debian-11"
 	isCloudInit = true
 	systemImage = true
 	installAgent = true
@@ -193,7 +47,7 @@ resource "workload-type" "nutanix-prism-debian-11" {
 	containerPorts = [{code = "debian.22"}]
 	actions = [{code = "generic-remove-node"}]
 	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-debian-11-20250218
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-debian-11-20260203
 	provisionType = "nutanix-prism-provision-provider"
 	backupType = "nutanixPrismSnapshot"
 }
@@ -242,14 +96,15 @@ resource "scale-action" "nutanix-prism-debian-11-single" {
 	}
 }
 
+
 //12
-resource "virtual-image" "nutanix-prism-image-morpheus-debian-12-20250218" {
-	code = "nutanix.prism.image.morpheus.debian.12.20250218"
+resource "virtual-image" "nutanix-prism-image-morpheus-debian-12-20260203" {
+	code = "nutanix.prism.image.morpheus.debian.12.20260203"
 	category = "nutanix.prism.image.morpheus.debian"
-	name = "Morpheus Debian 12 20250218"
+	name = "Morpheus Debian 12 20260203"
 	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/debian-12/morpheus-debian-12-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/debian-12"
+	remotePath = "https://morpheus-images.s3.amazonaws.com/qemu/20260203/debian-12/morpheus-debian-12-amd64-20260203.qcow2"
+	imagePath = "qemu/20260203/debian-12"
 	isCloudInit = true
 	systemImage = true
 	installAgent = true
@@ -268,7 +123,7 @@ resource "os-type-image" "nutanix-prism-image-morpheus-debian-12-disabled" {
 resource "os-type-image" "nutanix-prism-image-morpheus-debian-12" {
 	code               = "nutanix.prism.image.morpheus.debian.12"
 	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-debian-12-20250218
+	virtualImage       = virtual-image.nutanix-prism-image-morpheus-debian-12-20260203
 	account            = null
 	osType = {
 		code = "debian.12.64"
@@ -296,7 +151,7 @@ resource "workload-type" "nutanix-prism-debian-12" {
 	containerPorts = [{code = "debian.22"}]
 	actions = [{code = "generic-remove-node"}]
 	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-debian-12-20250218
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-debian-12-20260203
 	provisionType = "nutanix-prism-provision-provider"
 	backupType = "nutanixPrismSnapshot"
 }

--- a/src/main/resources/scribe/nutanix-prism-kube-templates.scribe
+++ b/src/main/resources/scribe/nutanix-prism-kube-templates.scribe
@@ -16,7 +16,7 @@ resource "workload-type" "kubernetes-ubuntu-22_04-nutanix-prism-amd64" {
   serverType       = "vm"
   providerType     = "nutanix-prism"
   checkTypeCode    = "vmCheck"
-  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20230307
+  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20260203
   containerPorts   = ["ubuntu.22"]
   provisionType    = "nutanix-prism-provision-provider"
   scripts          = [
@@ -44,7 +44,7 @@ resource "workload-type" "kubernetes-ubuntu-22_04-worker-nutanix-prism-amd64" {
   serverType       = "vm"
   providerType     = "nutanix-prism"
   checkTypeCode    = "vmCheck"
-  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20230307
+  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20260203
   containerPorts   = ["ubuntu.22"]
   provisionType    = "nutanix-prism-provision-provider"
   scripts          = [
@@ -107,7 +107,7 @@ resource "workload-type" "kubernetes-ubuntu-24_04-nutanix-prism-amd64" {
   serverType       = "vm"
   providerType     = "nutanix-prism"
   checkTypeCode    = "vmCheck"
-  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20250218
+  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20260203
   containerPorts   = ["ubuntu.22"]
   provisionType    = "nutanix-prism-provision-provider"
   scripts          = [
@@ -135,7 +135,7 @@ resource "workload-type" "kubernetes-ubuntu-24_04-worker-nutanix-prism-amd64" {
   serverType       = "vm"
   providerType     = "nutanix-prism"
   checkTypeCode    = "vmCheck"
-  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20250218
+  virtualImage     = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20260203
   containerPorts   = ["ubuntu.22"]
   provisionType    = "nutanix-prism-provision-provider"
   scripts          = [

--- a/src/main/resources/scribe/nutanix-prism-ubuntu-layouts.scribe
+++ b/src/main/resources/scribe/nutanix-prism-ubuntu-layouts.scribe
@@ -1,23 +1,20 @@
+//16
+resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-16_04" {
+	code = "nutanix.prism.image.morpheus.ubuntu.16.04"
+	category = "nutanix.prism.image.morpheus.ubuntu"
+	name = "Morpheus Ubuntu 16.04"
+	enabled = false
+	creatable = false
+}
+
+
 //18
 resource "instance-type-layout" "nutanix-prism-ubuntu-18_04-single" {
 	code = "nutanix-prism-ubuntu-18.04-single"
 	name = "Nutanix Prism Central VM"
-	account = null
-	sortOrder = 18
-	instanceVersion = "18.04"
 	description = "This will provision a single vm"
-	instanceType {
-		code = "ubuntu"
-	}
-	serverCount = 1
-	hasAutoScale = true
-	portCount = 1
-	serverType = "vm"
 	enabled = false
 	creatable = false
-	supportsConvertToManaged = true
-	actions = [{code = "ubuntu-add-node"}]
-	provisionType = "nutanix-prism-provision-provider"
 }
 
 

--- a/src/main/resources/scribe/nutanix-prism-ubuntu-layouts.scribe
+++ b/src/main/resources/scribe/nutanix-prism-ubuntu-layouts.scribe
@@ -1,99 +1,4 @@
-//16 - image for docker
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-16_04" {
-	code = "nutanix.prism.image.morpheus.ubuntu.16.04"
-	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 16.04"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/kvm/ubuntu/ubuntu-16_04_4-v1-amd64/morpheus-ubuntu-16_04_4-v1-amd64.qcow2"
-	imagePath = "kvm/ubuntu/ubuntu-16_04_4-v1-amd64"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "ubuntu.16.04.64"
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
 //18
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-18_04-20230131" {
-	code = "nutanix.prism.image.morpheus.ubuntu.18.04.20230131"
-	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 18.04 20230131"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20230131/ubuntu-18/morpheus-ubuntu-18_04-amd64-20230131.qcow2"
-	imagePath = "qemu/20230131/ubuntu-18"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "ubuntu.18.04.64"
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-18_04-20250218" {
-	code = "nutanix.prism.image.morpheus.ubuntu.18.04.20250218"
-	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 18.04 20250218"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/ubuntu-18/morpheus-ubuntu-18_04-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/ubuntu-18"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "ubuntu.18.04.64"
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-18_04" {
-	code               = "nutanix.prism.image.morpheus.ubuntu.18.04"
-	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-18_04-20250218
-	account            = null
-	osType = {
-		code = "ubuntu.18.04.64"
-		owner = null
-	}
-}
-
-
-resource "workload-type" "nutanix-prism-ubuntu-18_04" {
-	code = "nutanix-prism-ubuntu-18.04"
-	shortName = "ubuntu"
-	name = "Ubuntu 18.04"
-	account = null
-	ports = [22]
-	containerVersion = "18.04"
-	entryPoint = ""
-	mountLogs = "/var/log"
-	statTypeCode = "vm"
-	logTypeCode = "ubuntu"
-	showServerLogs = true
-	category = "ubuntu"
-	cloneType = "ubuntu"
-	priorityOrder = 0
-	serverType = "vm"
-	providerType = "nutanix-prism"
-	containerPorts = [{code = "ubuntu.22"}]
-	actions = [{code = "ubuntu-remove-node"}]
-	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-18_04-20250218
-	provisionType = "nutanix-prism-provision-provider"
-	backupType = "nutanixPrismSnapshot"
-}
-
-resource "workload-type-set" "nutanix-prism-ubuntu-18_04-set" {
-	code = "nutanix-prism-ubuntu-18.04-set"
-	containerType = workload-type.nutanix-prism-ubuntu-18_04
-	priorityOrder = 0
-	dynamicCount = true
-	containerCount = 1
-}
-
 resource "instance-type-layout" "nutanix-prism-ubuntu-18_04-single" {
 	code = "nutanix-prism-ubuntu-18.04-single"
 	name = "Nutanix Prism Central VM"
@@ -111,35 +16,19 @@ resource "instance-type-layout" "nutanix-prism-ubuntu-18_04-single" {
 	enabled = false
 	creatable = false
 	supportsConvertToManaged = true
-	containers = [
-		workload-type-set.nutanix-prism-ubuntu-18_04-set
-	]
 	actions = [{code = "ubuntu-add-node"}]
 	provisionType = "nutanix-prism-provision-provider"
 }
 
-resource "scale-action" "nutanix-prism-ubuntu-18_04-single" {
-	code = "nutanix-prism-ubuntu-18.04-single"
-	scaleType = "action"
-	layout = instance-type-layout.nutanix-prism-ubuntu-18_04-single
-	upAction {
-		code = "ubuntu-add-node"
-	}
-	downAction {
-		code = "ubuntu-remove-node"
-	}
-}
-
 
 //20
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-20_04-20250218" {
-	code = "nutanix.prism.image.morpheus.ubuntu.20.04.20250218.ubuntu.20.04"
+resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-20_04-20260203" {
+	code = "nutanix.prism.image.morpheus.ubuntu.20.04.20260203.ubuntu.20.04"
 	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 20.04 20250218"
+	name = "Morpheus Ubuntu 20.04 20260203"
 	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/ubuntu-20/morpheus-ubuntu-20_04-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/ubuntu-20"
+	remotePath = "https://morpheus-images.s3.amazonaws.com/qemu/20260203/ubuntu-20/morpheus-ubuntu-20_04-amd64-20260203.qcow2"
+	imagePath = "qemu/20260203/ubuntu-20"
 	isCloudInit = true
 	systemImage = true
 	installAgent = true
@@ -158,7 +47,7 @@ resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-20_04-disabled" {
 resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-20_04" {
 	code               = "nutanix.prism.image.morpheus.ubuntu.20.04"
 	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20250218
+	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	account            = null
 	osType = {
 		code = "ubuntu.20.04.64"
@@ -186,7 +75,7 @@ resource "workload-type" "nutanix-prism-ubuntu-20_04" {
 	containerPorts = [{code = "ubuntu.22"}]
 	actions = [{code = "ubuntu-remove-node"}]
 	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20250218
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-20_04-20260203
 	provisionType = "nutanix-prism-provision-provider"
 	backupType = "nutanixPrismSnapshot"
 }
@@ -236,31 +125,13 @@ resource "scale-action" "nutanix-prism-ubuntu-20_04-single" {
 }
 
 //22
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-22_04-20230307" {
-	code = "nutanix.prism.image.morpheus.ubuntu.22.04.20230307"
+resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-22_04-20260203" {
+	code = "nutanix.prism.image.morpheus.ubuntu.22.04.20260203"
 	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 22.04 20230307"
+	name = "Morpheus Ubuntu 22.04 20260203"
 	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20230307/ubuntu-22/morpheus-ubuntu-22_04-amd64-20230307.qcow2"
-	imagePath = "qemu/20230307/ubuntu-22"
-	isCloudInit = true
-	systemImage = true
-	installAgent = true
-	osType {
-		code = "ubuntu.22.04.64"
-	}
-	zoneType = "nutanix-prism-cloud"
-}
-
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-22_04-20250218" {
-	code = "nutanix.prism.image.morpheus.ubuntu.22.04.20250218"
-	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 22.04 20250218"
-	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/ubuntu-22/morpheus-ubuntu-22_04-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/ubuntu-22"
+	remotePath = "https://morpheus-images.s3.amazonaws.com/qemu/20260203/ubuntu-22/morpheus-ubuntu-22_04-amd64-20260203.qcow2"
+	imagePath = "qemu/20260203/ubuntu-22"
 	isCloudInit = true
 	systemImage = true
 	installAgent = true
@@ -271,22 +142,16 @@ resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-22_04-20250218" {
 	zoneType = "nutanix-prism-cloud"
 }
 
-resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-22_04-disabled" {
-  code               = "nutanix.prism.image.morpheus.ubuntu.22.04.20240604"
-  enabled            = false
-}
-
 resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-22_04" {
 	code               = "nutanix.prism.image.morpheus.ubuntu.22.04"
 	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20250218
+	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20260203
 	account            = null
 	osType = {
 		code = "ubuntu.22.04.64"
 		owner = null
 	}
 }
-
 
 resource "workload-type" "nutanix-prism-ubuntu-22_04" {
 	code = "nutanix-prism-ubuntu-22.04"
@@ -308,7 +173,7 @@ resource "workload-type" "nutanix-prism-ubuntu-22_04" {
 	containerPorts = [{code = "ubuntu.22"}]
 	actions = [{code = "ubuntu-remove-node"}]
 	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20250218
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-22_04-20260203
 	provisionType = "nutanix-prism-provision-provider"
 	backupType = "nutanixPrismSnapshot"
 }
@@ -357,16 +222,15 @@ resource "scale-action" "nutanix-prism-ubuntu-22_04-single" {
 	}
 }
 
+
 //24
-
-
-resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-24_04-20250218" {
-	code = "nutanix.prism.image.morpheus.ubuntu.24.04.20250218"
+resource "virtual-image" "nutanix-prism-image-morpheus-ubuntu-24_04-20260203" {
+	code = "nutanix.prism.image.morpheus.ubuntu.24.04.20260203"
 	category = "nutanix.prism.image.morpheus.ubuntu"
-	name = "Morpheus Ubuntu 24.04 20250218"
+	name = "Morpheus Ubuntu 24.04 20260203"
 	imageType = "qcow2"
-	remotePath = "https://s3-us-west-1.amazonaws.com/morpheus-images/qemu/20250218/ubuntu-24/morpheus-ubuntu-24_04-amd64-20250218.qcow2"
-	imagePath = "qemu/20250218/ubuntu-24"
+	remotePath = "https://morpheus-images.s3.amazonaws.com/qemu/20260203/ubuntu-24/morpheus-ubuntu-24_04-amd64-20260203.qcow2"
+	imagePath = "qemu/20260203/ubuntu-24"
 	isCloudInit = true
 	systemImage = true
 	installAgent = true
@@ -385,14 +249,13 @@ resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-24_04-disabled" {
 resource "os-type-image" "nutanix-prism-image-morpheus-ubuntu-24_04" {
 	code               = "nutanix.prism.image.morpheus.ubuntu.24.04"
 	provisionType      = "nutanix-prism-provision-provider"
-	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20250218
+	virtualImage       = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20260203
 	account            = null
 	osType = {
 		code = "ubuntu.24.04.64"
 		owner = null
 	}
 }
-
 
 resource "workload-type" "nutanix-prism-ubuntu-24_04" {
 	code = "nutanix-prism-ubuntu-24.04"
@@ -414,7 +277,7 @@ resource "workload-type" "nutanix-prism-ubuntu-24_04" {
 	containerPorts = [{code = "ubuntu.22"}]
 	actions = [{code = "ubuntu-remove-node"}]
 	checkTypeCode = "containerCheck"
-	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20250218
+	virtualImage = virtual-image.nutanix-prism-image-morpheus-ubuntu-24_04-20260203
 	provisionType = "nutanix-prism-provision-provider"
 	backupType = "nutanixPrismSnapshot"
 }
@@ -462,4 +325,3 @@ resource "scale-action" "nutanix-prism-ubuntu-24_04-single" {
 		code = "ubuntu-remove-node"
 	}
 }
-


### PR DESCRIPTION
### Issues:
- [MORPH-6120](https://hpe.atlassian.net/browse/MORPH-6120) - use new images (20260203)

### Description
This updates the OS images for Ubuntu 20.04, 22.04, 24.04; Debian 11, 12. This also removes most references to Ubuntu 18.04 and Debian 10 since we no longer support fresh instances on those OSes.