### PR TITLE
Fix removeWorkload returning error when VM already deleted

### DIFF
--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismProvisionProvider.groovy
@@ -1131,6 +1131,9 @@ class NutanixPrismProvisionProvider extends AbstractProvisionProvider implements
 				} else {
 					return ServiceResponse.error(removeResults.msg ?: 'Failed to remove vm')
 				}
+			} else if(removeResults.data?.code == 404 || opts?.force) {
+				// VM already deleted (404) or force flag set — treat as success
+				return ServiceResponse.success()
 			} else {
 				return ServiceResponse.error('Failed to remove vm')
 			}


### PR DESCRIPTION
When destroyVm returns 404 (VM not found on Nutanix), the VM is already gone and the removal should be considered successful. Previously this returned ServiceResponse.error which propagated up through the core service chain, causing force-deleted orphaned instances to loop indefinitely via the onDeleteInstanceFail retry mechanism.

Also treat opts.force=true as an override to skip cloud errors entirely.