### PR TITLE
MORPH-10741: Fix image location accumulation and slow option source queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ task(console, dependsOn: 'classes', type: JavaExec) {
 	classpath = sourceSets.main.runtimeClasspath
 }
 
-test {
+tasks.withType(Test).configureEach {
 	testLogging {
 		exceptionFormat = 'full'
 		showStandardStreams = true

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismOptionSourceProvider.groovy
@@ -73,14 +73,28 @@ class NutanixPrismOptionSourceProvider extends AbstractOptionSourceProvider {
 		Cloud tmpCloud = morpheusContext.async.cloud.get(cloudId).blockingGet()
 		def regionCode = tmpCloud.regionCode
 
-		// Grab the projections.. doing a filter pass first
-		ImageType[] imageTypes = [ImageType.qcow2, ImageType.ova]
-		def virtualImageIds = morpheusContext.async.virtualImage.listIdentityProjections(accountId, imageTypes).filter { it.deleted == false }.map{it.id}.toList().blockingGet()
+		// Find images that have a location for this cloud
+		def locationQuery = new DataQuery().withFilters([
+			new DataFilter('refType', 'ComputeZone'),
+			new DataFilter('refId', cloudId),
+		])
+		if (regionCode) {
+			locationQuery.withFilters(new DataFilter('imageRegion', regionCode))
+		}
+		def imageIdsWithLocation = morpheusContext.async.virtualImage.location.listIdentityProjections(locationQuery)
+			.map { it.virtualImage?.id }
+			.filter { it != null }
+			.toList().blockingGet().unique()
 
+		// Build a query for images belonging to this cloud or user-uploaded
+		ImageType[] imageTypes = [ImageType.qcow2, ImageType.ova]
+		def virtualImageIds = morpheusContext.async.virtualImage.listIdentityProjections(accountId, imageTypes)
+			.filter { it.deleted == false }
+			.map { it.id }
+			.toList().blockingGet()
 
 		List options = []
-		if(virtualImageIds.size() > 0) {
-
+		if (virtualImageIds.size() > 0) {
 			def query = new DataQuery().withFilters([
 				new DataFilter('active', true),
 				new DataFilter('id', 'in', virtualImageIds),
@@ -88,36 +102,27 @@ class NutanixPrismOptionSourceProvider extends AbstractOptionSourceProvider {
 					new DataFilter('owner.id', accountId),
 					new DataFilter('owner.id', null),
 					new DataFilter('visibility', 'public')
-				)
-			]).withJoins('locations', 'owner')
-			def additionalFilters = new DataOrFilter([
-				new DataFilter('category', "nutanix.prism.image.${cloudId}"),
-				new DataAndFilter(
-					new DataFilter("refType", "ComputeZone"),
-					new DataFilter("refId", cloudId)
 				),
-				new DataAndFilter(
-					new DataFilter("locations.refType", "ComputeZone"),
-					new DataFilter("locations.refId", cloudId)
+				new DataOrFilter(
+					new DataFilter('category', "nutanix.prism.image.${cloudId}"),
+					new DataAndFilter(
+						new DataFilter("refType", "ComputeZone"),
+						new DataFilter("refId", cloudId)
+					),
+					new DataFilter('id', 'in', imageIdsWithLocation ?: [0L]),
+					new DataAndFilter(
+						new DataFilter('userUploaded', true),
+						regionCode ? new DataFilter('imageRegion', regionCode) : new DataFilter('active', true)
+					)
 				)
-			])
-			if (regionCode) {
-				additionalFilters.withFilters([
-					new DataFilter('userUploaded', true),
-					new DataFilter('imageRegion', regionCode),
-					new DataFilter('locations.imageRegion', regionCode)
-				])
-			}
-			query.withFilters(additionalFilters)
-			options = morpheusContext.async.virtualImage.list(query).map { [name: it.name, value: it.id, locations: it.imageLocations, userUploaded: it.userUploaded] }.toList().blockingGet()
-		}
-
-		if(options.size() > 0) {
-			options = options.findAll{it.userUploaded || it.locations.size() == 0 || (it.locations.find {loc -> loc.refType == "ComputeZone" && loc.refId == cloudId})}.collect {[name: it.name, value: it.value]}.sort { it.name }
+			]).withJoins('owner')
+			options = morpheusContext.async.virtualImage.list(query)
+				.map { [name: it.name, value: it.id] }
+				.toList().blockingGet()
+				.sort { it.name }
 		}
 
 		options
-
 	}
 
 	def nutanixPrismNodeImage(args) {

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/NutanixPrismOptionSourceProvider.groovy
@@ -86,7 +86,6 @@ class NutanixPrismOptionSourceProvider extends AbstractOptionSourceProvider {
 			.filter { it != null }
 			.toList().blockingGet().unique()
 
-		// Build a query for images belonging to this cloud or user-uploaded
 		ImageType[] imageTypes = [ImageType.qcow2, ImageType.ova]
 		def virtualImageIds = morpheusContext.async.virtualImage.listIdentityProjections(accountId, imageTypes)
 			.filter { it.deleted == false }
@@ -95,29 +94,29 @@ class NutanixPrismOptionSourceProvider extends AbstractOptionSourceProvider {
 
 		List options = []
 		if (virtualImageIds.size() > 0) {
-			def query = new DataQuery().withFilters([
-				new DataFilter('active', true),
-				new DataFilter('id', 'in', virtualImageIds),
-				new DataOrFilter(
-					new DataFilter('owner.id', accountId),
-					new DataFilter('owner.id', null),
-					new DataFilter('visibility', 'public')
-				),
-				new DataOrFilter(
-					new DataFilter('category', "nutanix.prism.image.${cloudId}"),
-					new DataAndFilter(
-						new DataFilter("refType", "ComputeZone"),
-						new DataFilter("refId", cloudId)
+			options = morpheusContext.async.virtualImage.listIdentityProjections(
+				new DataQuery().withFilters([
+					new DataFilter('active', true),
+					new DataFilter('id', 'in', virtualImageIds),
+					new DataOrFilter(
+						new DataFilter('owner.id', accountId),
+						new DataFilter('owner.id', null),
+						new DataFilter('visibility', 'public')
 					),
-					new DataFilter('id', 'in', imageIdsWithLocation ?: [0L]),
-					new DataAndFilter(
-						new DataFilter('userUploaded', true),
-						regionCode ? new DataFilter('imageRegion', regionCode) : new DataFilter('active', true)
+					new DataOrFilter(
+						new DataFilter('category', "nutanix.prism.image.${cloudId}"),
+						new DataAndFilter(
+							new DataFilter("refType", "ComputeZone"),
+							new DataFilter("refId", cloudId)
+						),
+						new DataFilter('id', 'in', imageIdsWithLocation ?: [0L]),
+						new DataAndFilter(
+							new DataFilter('userUploaded', true),
+							regionCode ? new DataFilter('imageRegion', regionCode) : new DataFilter('active', true)
+						)
 					)
-				)
-			]).withJoins('owner')
-			options = morpheusContext.async.virtualImage.list(query)
-				.map { [name: it.name, value: it.id] }
+				])
+			).map { [name: it.name, value: it.id] }
 				.toList().blockingGet()
 				.sort { it.name }
 		}
@@ -129,21 +128,26 @@ class NutanixPrismOptionSourceProvider extends AbstractOptionSourceProvider {
 		log.debug "nutanixPrismNodeImage: ${args}"
 		def accountId = args?.size() > 0 ? args.getAt(0).accountId.toLong() : null
 
-		// Grab the projections.. doing a filter pass first
 		ImageType[] imageTypes = [ImageType.qcow2]
-		def virtualImageIds = morpheusContext.async.virtualImage.listIdentityProjections(accountId, imageTypes).filter { it.deleted == false}.map{it.id}.toList().blockingGet()
+		def virtualImageIds = morpheusContext.async.virtualImage.listIdentityProjections(accountId, imageTypes)
+			.filter { it.deleted == false }
+			.map { it.id }
+			.toList().blockingGet()
 
 		List options = []
 		if(virtualImageIds.size() > 0) {
-			options = morpheusContext.async.virtualImage.list(new DataQuery().withFilters([
-				new DataFilter('active', true),
-				new DataFilter('id', 'in', virtualImageIds),
-				new DataOrFilter(
-					new DataFilter('owner.id', accountId),
-					new DataFilter('owner.id', null),
-					new DataFilter('visibility', 'public')
-				)
-			]).withJoins('owner')).map {[name: it.name, value: it.id]}.toList().blockingGet()
+			// Use identity projections to avoid hydrating full VirtualImage GORM objects (87 columns)
+			options = morpheusContext.async.virtualImage.listIdentityProjections(
+				new DataQuery().withFilters([
+					new DataFilter('active', true),
+					new DataFilter('id', 'in', virtualImageIds),
+					new DataOrFilter(
+						new DataFilter('owner.id', accountId),
+						new DataFilter('owner.id', null),
+						new DataFilter('visibility', 'public')
+					)
+				])
+			).map { [name: it.name, value: it.id] }.toList().blockingGet()
 		}
 		if(options.size() > 0) {
 			options = options.sort { it.name.toLowerCase() }

--- a/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/sync/ImagesSync.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prism/plugin/sync/ImagesSync.groovy
@@ -98,13 +98,21 @@ class ImagesSync {
 		log.debug "addMissingVirtualImageLocations: ${objList?.size()}"
 
 		def names = objList.collect{it.status.name}?.unique()
+		def externalIds = objList.collect{it.metadata?.uuid}?.findAll{it}?.unique()
 		List<VirtualImageIdentityProjection> existingItems = []
 		def allowedImageTypes = ['qcow2']
 
 		def uniqueIds = [] as Set
 		Observable domainRecords = morpheusContext.async.virtualImage.listIdentityProjections(new DataQuery().withFilters([
 			new DataFilter<String>("imageType", "in", allowedImageTypes),
-			new DataFilter<Collection<String>>("name", "in", names),
+			new DataOrFilter(
+				new DataFilter("externalType", "null"),
+				new DataFilter("externalType", "!=", "template")
+			),
+			new DataOrFilter(
+				new DataFilter<Collection<String>>("externalId", "in", externalIds),
+				new DataFilter<Collection<String>>("name", "in", names)
+			),
 			new DataOrFilter(
 				new DataFilter<Boolean>("systemImage", true),
 				new DataOrFilter(


### PR DESCRIPTION
### Problem
 Two related issues were causing degraded behavior in Nutanix Prism:
 
 1. **Infinite VirtualImageLocation accumulation in ImagesSync** – The inner `SyncTask` was creating locations for template-type `VirtualImage` records that are invisible to the outer sync query (which excludes `externalType=template`). 
Each sync cycle would accumulate new orphaned locations, growing unboundedly.
 
 2. **Extremely slow image option sources** – `nutanixPrismProvisionImage` and `nutanixPrismNodeImage` were calling `virtualImage.list()` with `.withJoins('locations')`, which caused a Cartesian explosion as location counts grew, and fully
 hydrated GORM domain objects for every result. For ~1,000 images this took 10–12 seconds per call.
 
 ### Changes
 - **ImagesSync**: Filter out template-type `VirtualImage` records from the inner `SyncTask` query to prevent location creation for entries the outer query never touches. Also tightened matching to filter by both `externalId` and name.
 - **NutanixPrismOptionSourceProvider**: Removed `.withJoins('locations')` from the option source queries and replaced client-side location filtering with a pre-query on location projections. Replaced `virtualImage.list()` with 
`virtualImage.listIdentityProjections()` to return lightweight Hibernate column projections instead of fully hydrated domain objects.